### PR TITLE
Fix steam-user version check

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function TeamFortress2(steam) {
 		throw new Error('tf2 v3 only supports steam-user v4.2.0 or later.');
 	} else {
 		let parts = steam.packageVersion.split('.');
-		if (parts[0] < 4 || parts[1] < 2) {
+		if (parts[0] < 4 && parts[1] < 2) {
 			throw new Error(`node-tf2 v3 only supports node-steam-user v4.2.0 or later. ${steam.constructor.name} v${steam.packageVersion} given.`);
 		}
 	}


### PR DESCRIPTION
I can't use steam-user v5 because of this check:

https://github.com/DoctorMcKay/node-tf2/blob/5615801b08652a3544202275ad5d7f3cbef69e1b/index.js#L16-L24

The problem is that it checks if major version is less than 4 **or** minor version is less than 2. This means that steam-user v5.0.0 does not work because the minor version is less than 2.