### PR TITLE
feat/add-itemschema-caching

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -1,4 +1,6 @@
 const ByteBuffer = require('bytebuffer');
+const {Agent:HttpAgent} = require('http');
+const {Agent:HttpsAgent} = require('https');
 const {HttpClient} = require('@doctormckay/stdlib/http');
 const {Semaphore} = require('@doctormckay/stdlib/concurrency.js');
 const SteamID = require('steamid');
@@ -7,6 +9,11 @@ const VDF = require('kvparser');
 const TeamFortress2 = require('./index.js');
 const Language = require('./language.js');
 const Schema = require('./protobufs/generated/_load.js');
+
+const httpClient = new HttpClient({
+	httpAgent: new HttpAgent({ keepAlive: true, timeout: 10000 }),
+	httpsAgent: new HttpsAgent({ keepAlive: true, timeout: 10000 })
+});
 
 const handlers = TeamFortress2.prototype._handlers;
 
@@ -62,9 +69,7 @@ handlers[Language.UpdateItemSchema] = async function(body) {
 		this.emit('itemSchema', schemaVersion, schemaUrl);
 
 		if (schemaVersion !== g_ItemSchemaVersion) {
-			let client = new HttpClient();
-
-			let result = await client.request({
+			let result = await httpClient.request({
 				method: 'get',
 				url: schemaUrl
 			});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"url": "https://github.com/DoctorMcKay/node-tf2.git"
 	},
 	"dependencies": {
-		"@doctormckay/stdlib": "^2.7.1",
+		"@doctormckay/stdlib": "^2.9.1",
 		"bytebuffer": "^5.0.1",
 		"kvparser": "^1.0.2",
 		"protobufjs": "^7.2.5",


### PR DESCRIPTION
Added ability to cache items schema, when using multiple bots.

Without breaking changes (all events emitting the same way).

Also added class property `itemSchemaVersion`, which contains current items schema version (i don't know should it be documented in readme or not).