### PR TITLE
feat/add-ability-to-ignore-backpack-load

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -142,6 +142,8 @@ handlers[Language.SO_CacheSubscribed] = function(body) {
 		switch (cache.type_id) {
 			case 1:
 				// Backpack
+				if (!this.shouldLoadBackpack) break;
+
 				let items = cache.object_data.map((object) => {
 					let item = decodeProto(Schema.CSOEconItem, object);
 					let isNew = (item.inventory >>> 30) & 1;
@@ -179,7 +181,8 @@ handlers[Language.SO_Create] = function(body) {
 
 	let item = decodeProto(Schema.CSOEconItem, proto.object_data);
 	item.position = item.inventory & 0x0000FFFF;
-	this.backpack.push(item);
+	
+	if (this.backpack) this.backpack.push(item);
 	this.emit('itemAcquired', item);
 };
 

--- a/handlers.js
+++ b/handlers.js
@@ -178,7 +178,10 @@ handlers[Language.SO_Create] = function(body) {
 	}
 
 	let item = decodeProto(Schema.CSOEconItem, proto.object_data);
-	item.position = item.inventory & 0x0000FFFF;
+	
+	let isNew = (item.inventory >>> 30) & 1;
+	item.position = (isNew ? 0 : item.inventory & 0xFFFF);
+
 	this.backpack.push(item);
 	this.emit('itemAcquired', item);
 };

--- a/handlers.js
+++ b/handlers.js
@@ -191,10 +191,6 @@ handlers[Language.SO_Create] = function(body) {
 		return; // Not an item
 	}
 
-	if (!this.backpack) {
-		return; // We don't have our backpack yet!
-	}
-
 	let item = decodeProto(Schema.CSOEconItem, proto.object_data);
   
 	let isNew = (item.inventory >>> 30) & 1;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const VDF = require('kvparser');
 const Language = require('./language.js');
 const Schema = require('./protobufs/generated/_load.js');
 
+const g_ItemSchemaCache = new Map();
+
 const STEAM_APPID = 440;
 
 module.exports = TeamFortress2;
@@ -26,6 +28,24 @@ function TeamFortress2(steam) {
 	this._steam = steam;
 	this.haveGCSession = false;
 	this._isInTF2 = false;
+
+	Object.defineProperty(this, 'itemSchema', {
+		get: function() {
+			return g_ItemSchemaCache.get('itemSchema');
+		},
+		set: function(value) {
+			g_ItemSchemaCache.set('itemSchema', value);
+		}
+	});
+
+	Object.defineProperty(this, 'itemSchemaVersion', {
+		get: function() {
+			return g_ItemSchemaCache.get('itemSchemaVersion');
+		},
+		set: function(value) {
+			g_ItemSchemaCache.set('itemSchemaVersion', value);
+		}
+	});
 
 	this._steam.on('receivedFromGC', (appid, msgType, payload) => {
 		if (appid != STEAM_APPID) {

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function TeamFortress2(steam) {
 
 	this._steam = steam;
 	this.haveGCSession = false;
+	this.shouldLoadBackpack = true;
 	this._isInTF2 = false;
 
 	this._steam.on('receivedFromGC', (appid, msgType, payload) => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"url": "https://github.com/DoctorMcKay/node-tf2.git"
 	},
 	"dependencies": {
-		"@doctormckay/stdlib": "^2.7.1",
+		"@doctormckay/stdlib": "^2.9.1",
 		"bytebuffer": "^5.0.1",
 		"kvparser": "^1.0.2",
 		"protobufjs": "^7.2.5",


### PR DESCRIPTION
Now we can change class `shouldLoadBackpack` property to `false` for preventing population of class backpack.

For the sake of memory saving. Backpacks objects are huge and can consumes much ram.

Defaults to `true`, so, no breaking changes.