### PR TITLE
fix/new-items-positions

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -178,7 +178,10 @@ handlers[Language.SO_Create] = function(body) {
 	}
 
 	let item = decodeProto(Schema.CSOEconItem, proto.object_data);
-	item.position = item.inventory & 0x0000FFFF;
+	
+	let isNew = (item.inventory >>> 30) & 1;
+	item.position = (isNew ? 0 : item.inventory & 0xFFFF);
+
 	this.backpack.push(item);
 	this.emit('itemAcquired', item);
 };


### PR DESCRIPTION
I'm not exactly sure is that correct behavior, but when our bot acquires item (`itemAcquired` event) - position of this item is not set yet (via`setPosition` or `setPositions` methods).

Item's property `inventory` is still integer with huge value. After we manually set position to item, this value will change to our position number.

Previously we can't get right position, now we do same things, as when loading backpack here `handlers[Language.SO_CacheSubscribed]` and it's works fine.