### PR TITLE
fix/emiting-events-without-backpack-loaded 

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ The `premium` property of node-tf2 would now be true and the `backpackSlots` pro
 Emitted when we receive a new item. `item` is the item that we just received, and `tf2.backpack` is updated before the event is emitted.
 
 ### itemChanged
-- `oldItem` - The old item data
+- `oldItem` - The old item data (may be `null` if backpack is not loaded yet)
 - `newItem` - The new item data
 
 Emitted when an item in our backpack changes (e.g. style update, position changed, etc.).

--- a/handlers.js
+++ b/handlers.js
@@ -173,13 +173,12 @@ handlers[Language.SO_Create] = function(body) {
 		return; // Not an item
 	}
 
-	if (!this.backpack) {
-		return; // We don't have our backpack yet!
-	}
-
 	let item = decodeProto(Schema.CSOEconItem, proto.object_data);
-	item.position = item.inventory & 0x0000FFFF;
-	this.backpack.push(item);
+
+	let isNew = (item.inventory >>> 30) & 1;
+	item.position = (isNew ? 0 : item.inventory & 0xFFFF);
+
+	if (this.backpack) this.backpack.push(item);
 	this.emit('itemAcquired', item);
 };
 
@@ -199,22 +198,24 @@ handlers[Language.SO_UpdateMultiple] = function(body) {
 TeamFortress2.prototype._handleSOUpdate = function(so) {
 	switch (so.type_id) {
 		case 1:
-			if (!this.backpack) {
-				return; // We don't have our backpack yet!
-			}
-
 			let item = decodeProto(Schema.CSOEconItem, so.object_data);
-			item.position = item.inventory & 0x0000FFFF;
-			for (let i = 0; i < this.backpack.length; i++) {
-				if (this.backpack[i].id == item.id) {
-					let oldItem = this.backpack[i];
-					this.backpack[i] = item;
 
-					this.emit('itemChanged', oldItem, item);
+			let isNew = (item.inventory >>> 30) & 1;
+			item.position = (isNew ? 0 : item.inventory & 0xFFFF);
+
+			let oldItem = null;
+
+			if (this.backpack) {
+				for (let i = 0; i < this.backpack.length; i++) {
+					if (this.backpack[i].id != item.id) continue;
+					
+					oldItem = this.backpack[i];
+					this.backpack[i] = item;
 					break;
 				}
 			}
 
+			this.emit('itemChanged', oldItem, item);
 			break;
 		case 7:
 			let data = decodeProto(Schema.CSOEconGameAccountClient, so.object_data);
@@ -255,21 +256,21 @@ handlers[Language.SO_Destroy] = function(body) {
 		return; // Not an item
 	}
 
-	if (!this.backpack) {
-		return; // We don't have our backpack yet
-	}
-
 	let item = decodeProto(Schema.CSOEconItem, proto.object_data);
-	let itemData = null;
-	for (let i = 0; i < this.backpack.length; i++) {
-		if (this.backpack[i].id == item.id) {
-			itemData = this.backpack[i];
+
+	let isNew = (item.inventory >>> 30) & 1;
+	item.position = (isNew ? 0 : item.inventory & 0xFFFF);
+
+	if (this.backpack) {
+		for (let i = 0; i < this.backpack.length; i++) {
+			if (this.backpack[i].id != item.id) continue;
+
 			this.backpack.splice(i, 1);
 			break;
 		}
-	}
+}
 
-	this.emit('itemRemoved', itemData);
+	this.emit('itemRemoved', item);
 };
 
 // Item manipulation


### PR DESCRIPTION
Often we receive `SO_Create` messages before our backpack was loaded. 

If we not handle that because of lack of backpack, we can miss important info. Same for `SO_Destroy` and `SO_Update`.

Also fixed `item.position`, now that represents correct position (previously we can get 1 or -1 position if item was acquired in past and we didn't update position for this item).