### PR TITLE
fix/emitting-events-without-backpack-loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ The `premium` property of node-tf2 would now be true and the `backpackSlots` pro
 Emitted when we receive a new item. `item` is the item that we just received, and `tf2.backpack` is updated before the event is emitted.
 
 ### itemChanged
-- `oldItem` - The old item data
+- `oldItem` - The old item data (may be same as `newItem` if backpack was not loaded yet)
 - `newItem` - The new item data
 
 Emitted when an item in our backpack changes (e.g. style update, position changed, etc.).


### PR DESCRIPTION
Often we receive SO_Create messages before our backpack was loaded.

If we not handle that because of lack of backpack, we can miss important info. Same for SO_Destroy and SO_Update.

Also fixed `item.position`, now that represents correct position (previously we can get 1 or -1 position if item was acquired in past and we didn't update position for this item).